### PR TITLE
New revision codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ TestResults
 **.user
 **.suo
 **.sdf  
+.vs/*
 
 # resharper  
 /_[Rr]e[Ss]harper.*  
@@ -20,3 +21,7 @@ TestResults
 [Dd]esktop.ini
 
 RaspberrySharp.System.userprefs
+
+# Nuget packages
+packages/*
+!packages/repositories.config

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Raspberry.System provides utilities for Raspberry Pi boards, while using .NET co
 You can easily add a reference to it in your Visual Studio projects using the **[Raspberry.System Nuget](https://www.nuget.org/packages/Raspberry.System3)**.
 
 It currently support the following features:
-+ Automatic detection of various Raspberry Pi revisions, as of 2013-09, **Raspberry Pi model B rev1 and rev2 and Raspberry Pi model A**
++ Automatic detection of various Raspberry Pi revisions, as of 2017-11: **Raspberry Pi model B rev1 up to Pi 3 model B**
 + High resolution (about 1µs) timers

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -1,9 +1,11 @@
 #region References
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text;
 
 #endregion
 
@@ -13,29 +15,30 @@ namespace Raspberry
     /// Represents the Raspberry Pi mainboard.
     /// </summary>
     /// <remarks>
-    /// Version and revisions are based on <see cref="http://raspberryalphaomega.org.uk/2013/02/06/automatic-raspberry-pi-board-revision-detection-model-a-b1-and-b2/"/>.
+    /// Version and revisions are based on <see cref="https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md"/>.
     /// <see cref="http://www.raspberrypi-spy.co.uk/2012/09/checking-your-raspberry-pi-board-version/"/> for information.
+    /// NOTES on V3.1.2:
+    /// <list type="bullet">
+    /// <item>IsOverClocked has been removed. This used the "warranty" flag (i.e. void if overclocked) but this policy was changed.</item>
+    /// <item>Firmware has been changed to RevisionCode.</item>
+    /// </list>
     /// </remarks>
     public class Board
     {
+
         #region Fields
 
-        private static readonly Lazy<Board> board = new Lazy<Board>(LoadBoard);
-        
-        private readonly Dictionary<string, string> settings;
-        private readonly Lazy<Model> model;
-        private readonly Lazy<ConnectorPinout> connectorPinout;
+        private static Board board;
+        private uint revisionCode;
+        private IList<Core> cores = new List<Core>();
 
         #endregion
 
         #region Instance Management
 
-        private Board(Dictionary<string, string> settings)
+        private Board()
         {
-            model = new Lazy<Model>(LoadModel);
-            connectorPinout = new Lazy<ConnectorPinout>(LoadConnectorPinout);
-            
-            this.settings = settings;
+            LoadBoard();            
         }
 
         #endregion
@@ -45,10 +48,7 @@ namespace Raspberry
         /// <summary>
         /// Gets the current mainboard configuration.
         /// </summary>
-        public static Board Current
-        {
-            get { return board.Value; }
-        }
+        public static Board Current => board ?? ( board = new Board() );
 
         /// <summary>
         /// Gets a value indicating whether this instance is a Raspberry Pi.
@@ -56,28 +56,7 @@ namespace Raspberry
         /// <value>
         /// 	<c>true</c> if this instance is a Raspberry Pi; otherwise, <c>false</c>.
         /// </value>
-        public bool IsRaspberryPi
-        {
-            get
-            {
-                return Processor != Processor.Unknown;
-            }
-        }
-
-        /// <summary>
-        /// Gets the processor name.
-        /// </summary>
-        /// <value>
-        /// The name of the processor.
-        /// </value>
-        public string ProcessorName
-        {
-            get
-            {
-                string hardware;
-                return settings.TryGetValue("Hardware", out hardware) ? hardware : null;
-            }
-        }
+        public bool IsRaspberryPi { get; private set; }
 
         /// <summary>
         /// Gets the processor.
@@ -85,73 +64,41 @@ namespace Raspberry
         /// <value>
         /// The processor.
         /// </value>
-        public Processor Processor
+        public Processor Processor { get; private set; }
+
+        /// <summary>
+        /// Gets the board revision code. This is the number from cpuinfo containing many details about the board.
+        /// </summary>
+        public uint RevisionCode
         {
-            get
+            get => revisionCode;
+            private set
             {
-                Processor processor;
-                return Enum.TryParse(ProcessorName, true, out processor) ? processor : Processor.Unknown;
+                revisionCode = value;
+                ParseRevisionCode( value, SetBoardParams );
+                ConnectorPinout = LoadConnectorPinout();
             }
         }
 
         /// <summary>
-        /// Gets the board firmware version.
+        /// Gets the board revision, i.e. 1.1 etc.
         /// </summary>
-        public int Firmware
-        {
-            get
-            {
-                string revision;
-                int firmware;
-                if (settings.TryGetValue("Revision", out revision) 
-                    && !string.IsNullOrEmpty(revision) 
-                    && int.TryParse(revision, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out firmware))
-                    return firmware;
+        public Version Revision { get; private set; }
 
-                return 0;
-            }
-        }
+        /// <summary>
+        /// Gets the memory size in MB.
+        /// </summary>
+        public int MemorySize { get; private set; }
 
         /// <summary>
         /// Gets the serial number.
         /// </summary>
-        public string SerialNumber
-        {
-            get { 
-                string serial;
-                if (settings.TryGetValue("Serial", out serial) 
-                    && !string.IsNullOrEmpty(serial))
-                    return serial;
-
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether Raspberry Pi board is overclocked.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if Raspberry Pi is overclocked; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsOverclocked
-        {
-            get
-            {
-                var firmware = Firmware;
-                return (firmware & 0xFFFF0000) != 0;
-            }
-        }
+        public string SerialNumber { get; private set; }
 
         /// <summary>
         /// Gets the model.
         /// </summary>
-        /// <value>
-        /// The model.
-        /// </value>
-        public Model Model
-        {
-            get { return model.Value; }
-        }
+        public Model Model { get; private set; }
 
         /// <summary>
         /// Gets the connector revision.
@@ -160,101 +107,232 @@ namespace Raspberry
         /// The connector revision.
         /// </value>
         /// <remarks>See <see cref="http://raspi.tv/2014/rpi-gpio-quick-reference-updated-for-raspberry-pi-b"/> for more information.</remarks>
-        public ConnectorPinout ConnectorPinout
+        public ConnectorPinout ConnectorPinout { get; private set; }
+
+        /// <summary>
+        /// Gets the list of cores on this board.
+        /// </summary>
+        public IList<Core> Cores => cores;
+
+        /// <summary>
+        /// Pretty prints the board info.
+        /// </summary>
+        public override string ToString()
         {
-            get { return connectorPinout.Value; }
+            var sb = new StringBuilder( $"Board:\t\t{Model.GetDisplayName()}\n" +
+                   $"Revision code:\t0x{RevisionCode:X}\n" +
+                   $"Model:\t\t{Model}\n" +
+                   $"Revision:\t{Revision}\n" +
+                   $"Processor:\t{Processor}\n" +
+                   $"Memory size:\t{MemorySize} MB\n" +
+                   $"Connector:\t{ConnectorPinout}\n" +
+                   $"Serial#:\t{SerialNumber}\n" );
+
+            foreach ( var core in Cores ) sb.Append( "\n" + core );
+
+            return sb.ToString();
         }
 
         #endregion
 
         #region Private Helpers
 
-        private static Board LoadBoard()
+        private void LoadBoard()
         {
+            var readingCoreInfo = false;
+            IsRaspberryPi = true;
+            string[] cpuInfo;
             try
             {
-                const string filePath = "/proc/cpuinfo";
-                
-                var cpuInfo = File.ReadAllLines(filePath);
-                var settings = new Dictionary<string, string>();
-                var suffix = string.Empty;
-                
-                foreach(var l in cpuInfo)
-                {
-                    var separator = l.IndexOf(':');
-
-                    if (!string.IsNullOrWhiteSpace(l) && separator > 0)
-                    {
-                        var key = l.Substring(0, separator).Trim();
-                        var val = l.Substring(separator + 1).Trim();
-                        if (string.Equals(key, "processor", StringComparison.InvariantCultureIgnoreCase))
-                            suffix = "." + val;
-
-                        settings.Add(key + suffix, val);
-                    }
-                    else
-                        suffix = "";
-                }
-
-                return new Board(settings);
+                //const string filePath = "/proc/cpuinfo";
+                const string filePath = @"c:\ddata\Temp\cpuinfo";
+                cpuInfo = File.ReadAllLines(filePath);
             }
-            catch
+            catch (Exception ex)
             {
-                return new Board(new Dictionary<string, string>());
+                Tracing.TraceError("Unable to read cpuinfo - are you sure this is a Pi? " + ex.Message);
+                IsRaspberryPi = false;
+                return;
+            }
+
+            Core currentCore = null;
+            foreach (var l in cpuInfo)
+            {
+                var separator = l.IndexOf(':');
+
+                if (!string.IsNullOrWhiteSpace(l) && separator > 0)
+                {
+                    var key = l.Substring(0, separator).Trim().ToUpper();
+                    var val = l.Substring(separator + 1).Trim();
+                    switch (key)
+                    {
+                        case "REVISION":
+                            uint revision;
+                            if (uint.TryParse(val, NumberStyles.HexNumber, null, out revision))
+                            {
+                                RevisionCode = revision;
+                            }
+                            break;
+
+                        case "SERIAL":
+                            SerialNumber = val;
+                            break;
+
+                        case "PROCESSOR":
+                            int coreNum;
+                            if ( int.TryParse( val, out coreNum ) )
+                            {
+                                currentCore = new Core(coreNum);
+                                cores.Add( currentCore );
+                            }
+                            else
+                            {
+                                currentCore = null;
+                            }
+                            break;
+
+                        default:
+                            currentCore?.SetState(key, val);
+                            break;
+                    }
+                }
             }
         }
 
-        private Model LoadModel()
+        /// <summary>
+        /// Parses the Pi's revision code.
+        /// </summary>
+        public static void ParseRevisionCode( uint revisionCode, Action<Model, Version, int, Processor> setBoardParams )
         {
-            var firmware = Firmware;
-            switch (firmware & 0xFFFF)
+            var oldStyle = ( revisionCode & 0x00800000 ) == 0; // Bit 24
+            if ( oldStyle )
+            {
+                ParseOldRevisionCode( revisionCode, setBoardParams );
+                return;
+            }
+
+            var memSizeBits = ( revisionCode & 0x00700000 ) >> 20; // Bits 21-23
+            var memSize = 256;
+            switch ( memSizeBits )
+            {
+                case 1:
+                    memSize = 512;
+                    break;
+                case 2:
+                    memSize = 1024;
+                    break;
+            }
+
+            var procBits = ( revisionCode & 0x000F000 ) >> 12; // Bits 13-16
+            var proc = Processor.Bcm2835;
+            switch ( procBits )
+            {
+                case 1:
+                    proc = Processor.Bcm2836;
+                    break;
+                case 2:
+                    proc = Processor.Bcm2837;
+                    break;
+            }
+
+            var typeBits = ( revisionCode & 0x0000FF0 ) >> 4; // Bits 5-12
+            var type = Model.Unknown;
+            switch ( typeBits )
+            {
+                case 0x00:
+                    type = Model.A;
+                    break;
+                case 0x02:
+                    type = Model.APlus;
+                    break;
+                case 0x03:
+                    type = Model.BPlus;
+                    break;
+                case 0x04:
+                    type = Model.B2;
+                    break;
+                case 0x06:
+                    type = Model.ComputeModule;
+                    break;
+                case 0x08:
+                    type = Model.B3;
+                    break;
+                case 0x09:
+                    type = Model.Zero;
+                    break;
+                case 0x0a:
+                    type = Model.ComputeModule3;
+                    break;
+                case 0x0c:
+                    type = Model.ZeroW;
+                    break;
+            }
+
+            var revisionBits = revisionCode & 0x000000F; // Bottom 4 bits
+            var revision = new Version( 1, (int)revisionBits );
+            setBoardParams( type, revision, memSize, proc );
+        }
+
+        private static void ParseOldRevisionCode( uint revisionCode, Action<Model, Version, int, Processor> setBoardParams )
+        {
+            switch ( revisionCode & 0xFFFF )
             {
                 case 0x2:
                 case 0x3:
-                    return Model.BRev1;
+                    setBoardParams( Model.BRev1, new Version( 1, 0 ), 256, Processor.Bcm2835 );
+                    break;
 
                 case 0x4:
                 case 0x5:
                 case 0x6:
-                case 0xd:
-                case 0xe:
-                case 0xf:
-                    return Model.BRev2;
+                    setBoardParams( Model.BRev2, new Version( 2, 0 ), 256, Processor.Bcm2835 );
+                    break;
 
                 case 0x7:
                 case 0x8:
                 case 0x9:
-                    return Model.A;
+                    setBoardParams( Model.A, new Version( 2, 0 ), 256, Processor.Bcm2835 );
+                    break;
+
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                    setBoardParams( Model.BRev2, new Version( 2, 0 ), 512, Processor.Bcm2835 );
+                    break;
 
                 case 0x10:
-                    return Model.BPlus;
+                    setBoardParams( Model.BPlus, new Version( 1, 0 ), 512, Processor.Bcm2835 );
+                    break;
 
                 case 0x11:
-                    return Model.ComputeModule;
+                case 0x14:
+                    setBoardParams( Model.ComputeModule, new Version( 1, 0 ), 512, Processor.Bcm2835 );
+                    break;
 
                 case 0x12:
-                    return Model.APlus;
+                    setBoardParams( Model.APlus, new Version( 1, 1 ), 256, Processor.Bcm2835 );
+                    break;
 
-                case 0x1040:
-                case 0x1041:
-                    return Model.B2;
+                case 0x13:
+                    setBoardParams( Model.BPlus, new Version( 1, 2 ), 512, Processor.Bcm2835 );
+                    break;
 
-                case 0x0092:
-                case 0x0093:
-                    return Model.Zero;
+                case 0x15:
+                    setBoardParams( Model.APlus, new Version( 1, 1 ), 512, Processor.Bcm2835 ); // Ambiguous - could have 256MB.
+                    break;
 
-                case 0x00C1:
-                    return Model.ZeroW;
-
-                case 0x2082:
-                    return Model.B3;
-                    
-                case 0x20A0:
-                    return Model.ComputeModule3;
-                    
                 default:
-                    return Model.Unknown;
+                    setBoardParams( Model.Unknown, new Version( 0, 0 ), 0, Processor.Bcm2835 );
+                    break;
             }
+        }
+
+        private void SetBoardParams(Model model, Version revision, int memSize, Processor proc )
+        {
+            Model = model;
+            Revision = revision;
+            MemorySize = memSize;
+            Processor = proc;
         }
 
         private ConnectorPinout LoadConnectorPinout()
@@ -273,8 +351,9 @@ namespace Raspberry
                 case Model.APlus:
                 case Model.B2:
                 case Model.Zero:
+                case Model.ZeroW:
                 case Model.B3:
-                case Model.ComputeModule3:                    
+                case Model.ComputeModule3:
                     return ConnectorPinout.Plus;
 
                 default:

--- a/Raspberry.System/Core.cs
+++ b/Raspberry.System/Core.cs
@@ -1,0 +1,71 @@
+﻿
+namespace Raspberry
+{
+    /// <summary>
+    /// Contains information about an R-Pi core.
+    /// </summary>
+    public class Core
+    {
+        public Core( int procNumber )
+        {
+            ProcessorNumber = procNumber;
+        }
+
+        /// <summary>
+        /// The number of this core.
+        /// </summary>
+        public int ProcessorNumber { get; }
+
+        /// <summary>
+        /// The model name of this core.
+        /// </summary>
+        public string ModelName { get; internal set; }
+
+        /// <summary>
+        /// Bogus MIPS estimate for this core.
+        /// </summary>
+        public double BogoMips { get; internal set; }
+
+        /// <summary>
+        /// Features of this core.
+        /// </summary>
+        public string Features { get; internal set; }
+
+        /// <summary>
+        /// Converts core information to string format.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"Core:\t\t{ProcessorNumber}\n" +
+                   $"Model name:\t{ModelName}\n" +
+                   $"BogoMIPS:\t{BogoMips}\n" +
+                   $"Features:\t{Features}\n";
+        }
+
+        internal void SetState( string key, string val )
+        {
+            switch ( key )
+            {
+                case "MODEL NAME":
+                    ModelName = val;
+                    break;
+
+                case "BOGOMIPS":
+                    double bmips;
+                    if (double.TryParse(val, out bmips))
+                    {
+                        BogoMips = bmips;
+                    }
+                    break;
+
+                case "FEATURES":
+                    Features = val;
+                    break;
+
+                case "CPU IMPLEMENTER":
+                    break;
+
+            }
+        }
+    }
+}

--- a/Raspberry.System/Core.cs
+++ b/Raspberry.System/Core.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Globalization;
+
 namespace Raspberry
 {
     /// <summary>
@@ -32,40 +34,89 @@ namespace Raspberry
         public string Features { get; internal set; }
 
         /// <summary>
+        /// Gets the APU implementer code
+        /// </summary>
+        public int CpuImplementer { get; internal set; }
+
+        /// <summary>
+        /// Gets the CPU architecture code.
+        /// </summary>
+        public int CpuArchitecture { get; internal set; }
+
+        /// <summary>
+        /// Gets the CPU variant code.
+        /// </summary>
+        public int CpuVariant { get; internal set; }
+
+        /// <summary>
+        /// Gets the CPU part code.
+        /// </summary>
+        public int CpuPart { get; internal set; }
+
+        /// <summary>
+        /// Gets the CPU revision code.
+        /// </summary>
+        public int CpuRevision { get; internal set; }
+
+        /// <summary>
         /// Converts core information to string format.
         /// </summary>
         public override string ToString()
         {
             return $"Core:\t\t{ProcessorNumber}\n" +
-                   $"Model name:\t{ModelName}\n" +
-                   $"BogoMIPS:\t{BogoMips}\n" +
-                   $"Features:\t{Features}\n";
+                   $"  -> Model:\t{ModelName}\n" +
+                   $"  -> BogoMIPS:\t{BogoMips}\n" +
+                   $"  -> Features:\t{Features}\n" +
+                   $"  -> CPU:\timplementer=0x{CpuImplementer:X}, arch={CpuArchitecture}, variant=0x{CpuVariant:X}, " +
+                   $"part=0x{CpuPart:X}, rev={CpuRevision}\n";
         }
 
         internal void SetState( string key, string val )
         {
             switch ( key )
             {
-                case "MODEL NAME":
+                case "model name":
                     ModelName = val;
                     break;
 
-                case "BOGOMIPS":
+                case "bogomips":
                     double bmips;
-                    if (double.TryParse(val, out bmips))
+                    if ( double.TryParse( val, out bmips ) )
                     {
                         BogoMips = bmips;
                     }
                     break;
 
-                case "FEATURES":
+                case "features":
                     Features = val;
                     break;
 
-                case "CPU IMPLEMENTER":
+                case "cpu implementer":
+                    CpuImplementer = ParseInt( val, NumberStyles.HexNumber );
                     break;
 
+                case "cpu architecture":
+                    CpuArchitecture = ParseInt( val );
+                    break;
+
+                case "cpu variant":
+                    CpuVariant = ParseInt( val, NumberStyles.HexNumber );
+                    break;
+
+                case "cpu part":
+                    CpuPart = ParseInt( val, NumberStyles.HexNumber );
+                    break;
+
+                case "cpu revision":
+                    CpuRevision = ParseInt( val );
+                    break;
             }
+        }
+
+        private int ParseInt( string val, NumberStyles numberStyle = NumberStyles.Integer )
+        {
+            int.TryParse( val, numberStyle, null, out int ret );
+            return ret;
         }
     }
 }

--- a/Raspberry.System/Model.cs
+++ b/Raspberry.System/Model.cs
@@ -84,7 +84,7 @@ namespace Raspberry
             switch (model)
             {
                 case Model.Unknown:
-                    return null;
+                    return "Unknown - not a Pi!";
                 case Model.A:
                     return "Raspberry Pi Model A";
                 case Model.APlus:

--- a/Raspberry.System/Processor.cs
+++ b/Raspberry.System/Processor.cs
@@ -11,18 +11,18 @@ namespace Raspberry
         Unknown,
 
         /// <summary>
-        /// Processor is a BCM2708.
+        /// Processor is a BCM2835. (Used to be referred to as BCM2708.)
         /// </summary>
-        Bcm2708,
+        Bcm2835,
 
         /// <summary>
-        /// Processor is a BCM2709.
+        /// Processor is a BCM2836. (Used to be referred to as BCM2709.)
         /// </summary>
-        Bcm2709,
+        Bcm2836,
 
         /// <summary>
-        /// Processor is BCM2835
+        /// Processor is BCM2837
         /// </summary>
-        BCM2835 // <- added this one JJ FIX per RB3/CM3
+        Bcm2837
     }
 }

--- a/Raspberry.System/Properties/AssemblyInfo.cs
+++ b/Raspberry.System/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.1.0")]
-[assembly: AssemblyFileVersion("3.1.1.0")]
+[assembly: AssemblyVersion("3.1.2.0")]
+[assembly: AssemblyFileVersion("3.1.2.0")]

--- a/Raspberry.System/Raspberry.System.csproj
+++ b/Raspberry.System/Raspberry.System.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="Board.cs" />
     <Compile Include="ConnectorPinout.cs" />
+    <Compile Include="Core.cs" />
     <Compile Include="Model.cs" />
     <Compile Include="Processor.cs" />
     <Compile Include="Timers\Interop.cs" />
@@ -48,6 +49,7 @@
     <Compile Include="Timers\StandardTimer.cs" />
     <Compile Include="Timers\Timer.cs" />
     <Compile Include="Timers\TimeSpanUtility.cs" />
+    <Compile Include="Tracing.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Raspberry.System/Tracing.cs
+++ b/Raspberry.System/Tracing.cs
@@ -1,0 +1,22 @@
+﻿
+using System.Diagnostics;
+
+namespace Raspberry
+{
+    /// <summary>
+    /// Adds tracing support for the assembly.
+    /// </summary>
+    public class Tracing
+    {
+        /// <summary>
+        /// Trace switch for the Raspberry.System assembly.
+        /// </summary>
+        public static TraceSwitch raspberrySystemTraceSwitch = new TraceSwitch("RPi-System", "Raspberry.System trace switch", "Off");
+        internal const string traceCat = "RPi-System";
+
+        public static void TraceError( string message )
+        {
+            Trace.WriteLineIf(raspberrySystemTraceSwitch.TraceError, message, traceCat);
+        }
+    }
+}

--- a/Raspberry.System/Tracing.cs
+++ b/Raspberry.System/Tracing.cs
@@ -11,12 +11,28 @@ namespace Raspberry
         /// <summary>
         /// Trace switch for the Raspberry.System assembly.
         /// </summary>
-        public static TraceSwitch raspberrySystemTraceSwitch = new TraceSwitch("RPi-System", "Raspberry.System trace switch", "Off");
+        public static TraceSwitch raspberrySystemTraceSwitch = new TraceSwitch( "RPi-System", "Raspberry.System trace switch", "Off" );
+
         internal const string traceCat = "RPi-System";
 
         public static void TraceError( string message )
         {
-            Trace.WriteLineIf(raspberrySystemTraceSwitch.TraceError, message, traceCat);
+            Trace.WriteLineIf( raspberrySystemTraceSwitch.TraceError, message, traceCat );
+        }
+
+        public static void TraceWarning( string message )
+        {
+            Trace.WriteLineIf( raspberrySystemTraceSwitch.TraceWarning, message, traceCat );
+        }
+
+        public static void TraceInfo( string message )
+        {
+            Trace.WriteLineIf( raspberrySystemTraceSwitch.TraceWarning, message, traceCat );
+        }
+
+        public static void TraceVerbose( string message )
+        {
+            Trace.WriteLineIf( raspberrySystemTraceSwitch.TraceVerbose, message, traceCat );
         }
     }
 }

--- a/RaspberrySharp.System.sln
+++ b/RaspberrySharp.System.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DE3AA526-5A9D-465A-B9B0-7A07AE6824B5}"
 	ProjectSection(SolutionItems) = preProject
@@ -22,6 +22,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9D7C75
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{7102091A-58D6-4ACC-90B7-6729AEF0586F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{8759C074-D71D-4B13-B6E0-911C5C725EC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Raspberry.System", "UnitTests\Tests.Raspberry.System\Tests.Raspberry.System.csproj", "{5796DDAD-0499-46FD-BD21-65E1641CB72D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,11 +57,27 @@ Global
 		{51780F8A-E5F5-4DC8-84B4-B282800A3396}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{51780F8A-E5F5-4DC8-84B4-B282800A3396}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{51780F8A-E5F5-4DC8-84B4-B282800A3396}.Release|x86.ActiveCfg = Release|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{51780F8A-E5F5-4DC8-84B4-B282800A3396} = {7102091A-58D6-4ACC-90B7-6729AEF0586F}
+		{5796DDAD-0499-46FD-BD21-65E1641CB72D} = {8759C074-D71D-4B13-B6E0-911C5C725EC5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ACB622C0-D7FD-41E6-9F29-20CD1630E1D4}
 	EndGlobalSection
 EndGlobal

--- a/Test.Board/Program.cs
+++ b/Test.Board/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Raspberry;
 
 namespace Test.Board
@@ -7,16 +8,19 @@ namespace Test.Board
     {
         static void Main()
         {
+            // Setup tracing for test app
+            Tracing.raspberrySystemTraceSwitch.Level = TraceLevel.Verbose;
+            Trace.Listeners.Add( new ConsoleTraceListener() );
+
             var board = Raspberry.Board.Current;
 
-            if (!board.IsRaspberryPi)
-                Console.WriteLine("System is not a Raspberry Pi");
+
+            if ( !board.IsRaspberryPi )
+                Console.WriteLine( "System is not a Raspberry Pi" );
             else
             {
-                Console.WriteLine("Raspberry Pi running on {0} processor", board.Processor);
-                Console.WriteLine("Firmware rev{0}, board model {1} ({2})", board.Firmware, board.Model, board.Model.GetDisplayName() ?? "Unknown");
-                Console.WriteLine();
-                Console.WriteLine("Serial number: {0}", board.SerialNumber);
+                Console.WriteLine( "Raspberry Pi running on {0} processor.", board.Processor );
+                Console.WriteLine( board );
             }
         }
     }

--- a/Test.Board/Program.cs
+++ b/Test.Board/Program.cs
@@ -19,7 +19,7 @@ namespace Test.Board
                 Console.WriteLine( "System is not a Raspberry Pi" );
             else
             {
-                Console.WriteLine( "Raspberry Pi running on {0} processor.", board.Processor );
+                Console.WriteLine( "Raspberry Pi running on {0} processor.\n", board.Processor );
                 Console.WriteLine( board );
             }
         }

--- a/UnitTests/Tests.Raspberry.System/Properties/AssemblyInfo.cs
+++ b/UnitTests/Tests.Raspberry.System/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Tests.Raspberry.System")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Tests.Raspberry.System")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5796ddad-0499-46fd-bd21-65e1641cb72d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests/Tests.Raspberry.System/TestNewStyleRevisionParsing.cs
+++ b/UnitTests/Tests.Raspberry.System/TestNewStyleRevisionParsing.cs
@@ -1,0 +1,132 @@
+﻿
+using System;
+using NUnit.Framework;
+using Raspberry;
+
+namespace Tests.Raspberry.System
+{
+    [TestFixture]
+    public class TestNewStyleRevisionParsing
+    {
+        [TestCase]
+        public void CanParseAPlusRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( model, Model.APlus );
+                Assert.AreEqual( version, new Version( 1, 1 ) );
+                Assert.AreEqual( memSize, 512 );
+                Assert.AreEqual( proc, Processor.Bcm2835 );
+            };
+            Board.ParseRevisionCode( 0x900021, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParseBPlusRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( model, Model.BPlus );
+                Assert.AreEqual( version, new Version( 1, 2 ) );
+                Assert.AreEqual( memSize, 512 );
+                Assert.AreEqual( proc, Processor.Bcm2835 );
+            };
+            Board.ParseRevisionCode( 0x900032, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParseZero12RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.Zero, model );
+                Assert.AreEqual( new Version( 1, 2 ), version );
+                Assert.AreEqual( 512, memSize );
+                Assert.AreEqual( Processor.Bcm2835, proc );
+            };
+            Board.ParseRevisionCode( 0x900092, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParseZero13RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.Zero, model );
+                Assert.AreEqual( new Version( 1, 3 ), version );
+                Assert.AreEqual( 512, memSize );
+                Assert.AreEqual( Processor.Bcm2835, proc );
+            };
+            Board.ParseRevisionCode( 0x900093, setModelParams );
+            Board.ParseRevisionCode( 0x920093, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParseZeroWRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.ZeroW, model );
+                Assert.AreEqual( new Version( 1, 1 ), version );
+                Assert.AreEqual( 512, memSize );
+                Assert.AreEqual( Processor.Bcm2835, proc );
+            };
+            Board.ParseRevisionCode( 0x9000C1, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParse2B10RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.B2, model );
+                Assert.AreEqual( new Version( 1, 0 ), version );
+                Assert.AreEqual( 1024, memSize );
+                Assert.AreEqual( Processor.Bcm2836, proc );
+            };
+            Board.ParseRevisionCode( 0xA01040, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParse2B11RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.B2, model );
+                Assert.AreEqual( new Version( 1, 1 ), version );
+                Assert.AreEqual( 1024, memSize );
+                Assert.AreEqual( Processor.Bcm2836, proc );
+            };
+            Board.ParseRevisionCode( 0xA01041, setModelParams );
+            Board.ParseRevisionCode( 0xA21041, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParse2B12RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.B2, model );
+                Assert.AreEqual( new Version( 1, 2 ), version );
+                Assert.AreEqual( 1024, memSize );
+                Assert.AreEqual( Processor.Bcm2837, proc );
+            };
+            Board.ParseRevisionCode( 0xA22042, setModelParams );
+        }
+
+        [TestCase]
+        public void CanParse3BRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setModelParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.B3, model );
+                Assert.AreEqual( new Version( 1, 2 ), version );
+                Assert.AreEqual( 1024, memSize );
+                Assert.AreEqual( Processor.Bcm2837, proc );
+            };
+            Board.ParseRevisionCode( 0xA02082, setModelParams );
+            Board.ParseRevisionCode( 0xA22082, setModelParams );
+            Board.ParseRevisionCode( 0xA32082, setModelParams );
+        }
+    }
+}

--- a/UnitTests/Tests.Raspberry.System/TestOldStyleRevisionParsing.cs
+++ b/UnitTests/Tests.Raspberry.System/TestOldStyleRevisionParsing.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using NUnit.Framework;
+using Raspberry;
+
+namespace Tests.Raspberry.System
+{
+    [TestFixture]
+    public class TestOldStyleRevisionParsing
+    {
+        [TestCase]
+        public void CanParseBRev1RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual(Model.BRev1, model );
+                Assert.AreEqual(new Version(1, 0), version );
+                Assert.AreEqual( 256, memSize );
+                Assert.AreEqual(Processor.Bcm2835, proc );
+            };
+            Board.ParseRevisionCode( 0x0002, setBoardParams );
+            Board.ParseRevisionCode( 0x0003, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseBRev2RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.BRev2, model);
+                Assert.AreEqual( new Version( 2, 0 ), version);
+                Assert.AreEqual( 256, memSize);
+                Assert.AreEqual( Processor.Bcm2835, proc);
+            };
+            Board.ParseRevisionCode( 0x0004, setBoardParams );
+            Board.ParseRevisionCode( 0x0005, setBoardParams );
+            Board.ParseRevisionCode( 0x0006, setBoardParams );
+        }
+
+        public void CanParseARev2RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.BRev1, model);
+                Assert.AreEqual( new Version( 2, 0 ), version );
+                Assert.AreEqual( 256, memSize );
+                Assert.AreEqual( Processor.Bcm2835, proc );
+            };
+            Board.ParseRevisionCode( 0x0007, setBoardParams );
+            Board.ParseRevisionCode( 0x0008, setBoardParams );
+            Board.ParseRevisionCode( 0x0009, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseBRev2512MbRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.BRev2,model );
+                Assert.AreEqual( new Version( 2, 0 ), version);
+                Assert.AreEqual( 512, memSize);
+                Assert.AreEqual( Processor.Bcm2835, proc);
+            };
+            Board.ParseRevisionCode( 0x000d, setBoardParams );
+            Board.ParseRevisionCode( 0x000e, setBoardParams );
+            Board.ParseRevisionCode( 0x000f, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseBPlusRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.BPlus, model);
+                Assert.AreEqual( new Version( 1, 0 ), version);
+                Assert.AreEqual( 512, memSize);
+                Assert.AreEqual( Processor.Bcm2835, proc);
+            };
+            Board.ParseRevisionCode( 0x0010, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseComputerModuleRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.ComputeModule, model);
+                Assert.AreEqual( new Version( 1, 0 ), version);
+                Assert.AreEqual( 512, memSize);
+                Assert.AreEqual( Processor.Bcm2835, proc);
+            };
+            Board.ParseRevisionCode( 0x0011, setBoardParams );
+            Board.ParseRevisionCode( 0x0014, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseAPlusRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.APlus, model);
+                Assert.AreEqual( new Version( 1, 1 ), version);
+                Assert.AreEqual( 256, memSize);
+                Assert.AreEqual( Processor.Bcm2835, proc);
+            };
+            Board.ParseRevisionCode( 0x0012, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseBPlusV12RevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.BPlus, model);
+                Assert.AreEqual( new Version( 1, 2 ), version);
+                Assert.AreEqual( 512, memSize);
+                Assert.AreEqual( Processor.Bcm2835, proc);
+            };
+            Board.ParseRevisionCode( 0x0013, setBoardParams );
+        }
+
+        [TestCase]
+        public void CanParseAPlus512MbRevisionCode()
+        {
+            Action<Model, Version, int, Processor> setBoardParams = ( model, version, memSize, proc ) =>
+            {
+                Assert.AreEqual( Model.APlus, model );
+                Assert.AreEqual( new Version( 1, 1 ), version );
+                Assert.AreEqual( 512, memSize );
+                Assert.AreEqual( Processor.Bcm2835, proc );
+            };
+            Board.ParseRevisionCode( 0x0015, setBoardParams );
+        }
+    }
+}

--- a/UnitTests/Tests.Raspberry.System/Tests.Raspberry.System.csproj
+++ b/UnitTests/Tests.Raspberry.System/Tests.Raspberry.System.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5796DDAD-0499-46FD-BD21-65E1641CB72D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tests.Raspberry.System</RootNamespace>
+    <AssemblyName>Tests.Raspberry.System</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestNewStyleRevisionParsing.cs" />
+    <Compile Include="TestOldStyleRevisionParsing.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Raspberry.System\Raspberry.System.csproj">
+      <Project>{2c0c9aaf-4edd-4c79-961b-e7bc4fc4eb0c}</Project>
+      <Name>Raspberry.System</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/UnitTests/Tests.Raspberry.System/packages.config
+++ b/UnitTests/Tests.Raspberry.System/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.8.1" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
I think that the support for all current RPi revision codes is complete. I've tested on:

- Pi Zero W - BCM2835
- Pi2 Model B - BCM2836
- Pi3 Model B - BCM2837
